### PR TITLE
Fix link to contributing

### DIFF
--- a/app/docs/index.md
+++ b/app/docs/index.md
@@ -162,5 +162,5 @@ await aws({
 ## Join the movement
 
 - [Learn how to author AWS service plugins](/plugin-api)
-- [Expand and improve the aws-lite ecosystem](/contribute)
+- [Expand and improve the aws-lite ecosystem](/contributing)
 - [Join the Discord](https://discord.com/invite/y5A2eTsCRX)


### PR DESCRIPTION
Was going to `/contribute` which is empty
